### PR TITLE
Autopublish + Artefacts on Error 

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
-    - uses:  cryptic-wizard/run-specflow-tests@v1.2.0
+    - uses:  ./
       with:
         test-assembly-dll: RunSpecflowTests/bin/Debug/netcoreapp3.1/RunSpecflowTests.dll
         test-execution-json: RunSpecflowTests/bin/Debug/netcoreapp3.1/TestExecution.json
@@ -23,11 +23,10 @@ jobs:
         configuration: 'Debug'
         logger: trx
         logger-file-name: ../../CalculatorResults.trx
-    - name: Publish Specflow Test Results
+    - name: Publish Specflow Test Logs
       if: success() || failure()
       uses: actions/upload-artifact@v2
       with:
-        name: SpecflowTestResults
+        name: SpecflowLogs
         path: |
-          CalculatorResults.html
           CalculatorResults.trx

--- a/.github/workflows/dotnetnoartifacts.yml
+++ b/.github/workflows/dotnetnoartifacts.yml
@@ -1,4 +1,4 @@
-name: .NET 6.0
+name: .NET 6.0 No Artifacts
 on:
   push:
 
@@ -21,3 +21,4 @@ jobs:
         test-execution-json: TestExecution.json
         output-html: CalculatorResults.html
         framework: net6.0
+        upload-artifact: false

--- a/README.md
+++ b/README.md
@@ -27,11 +27,6 @@ steps:
     test-assembly-dll: MySpecflowProject.dll
     test-execution-json: TestExecution.json
     output-html: MyTestResults.html
- - uses: actions/upload-artifact@v2
-  if: success() || failure()
-  with:
-    name: SpecflowTestResults
-    path: MyTestResults.html
 ```
 
 #### Test Multiple Operating Systems in the Same Workflow:
@@ -55,11 +50,6 @@ jobs:
       test-assembly-dll: MySpecflowProject.dll
       test-execution-json: TestExecution.json
       output-html: ${{ matrix.os }}.html
-  - uses: actions/upload-artifact@v2
-    if: success() || failure()
-    with:
-      name: SpecflowTestResults
-      path: ${{ matrix.os }}.html
 ```
 
 #### Test Multiple Frameworks in Separate Workflows:
@@ -112,7 +102,6 @@ logger-file-name:
 Features planned when ['uses' keyword is implemented in composite actions](https://github.com/actions/runner/issues/646)
 * Checkout automatically
 * Setup dotnet automatically
-* Upload artifacts automatically
 * Dotnet framework matrix testing
 ## Tools
 * [Visual Studio](https://visualstudio.microsoft.com/vs/)

--- a/RunSpecflowTests/RunSpecflowTests.csproj
+++ b/RunSpecflowTests/RunSpecflowTests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.50" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.57" />
     <PackageReference Include="SpecFlow.NUnit" Version="3.9.22" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Run SpecFlow Tests'
 description: 'A Github Action to run SpecFlow tests and create a LivingDoc'
-author: 'awgeorge'
+author: 'cryptic-wizard'
 branding:
   icon: check-square
   color: green

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Run SpecFlow Tests'
 description: 'A Github Action to run SpecFlow tests and create a LivingDoc'
-author: 'cryptic-wizard'
+author: 'awgeorge'
 branding:
   icon: check-square
   color: green
@@ -48,52 +48,54 @@ inputs:
     description: "Dotnet test log file name; required if logger is defined (example: MyTestResults.trx)"
     required: false
     default: 'null'
-  #upload-artifact: TODO on composite action 'uses'
-    #description: "Set to false to disable uploading <LivingDoc.html> artifact automatically"
-    #required: false
-    #default: 'true'
+  upload-artifact:
+    description: "Set to false to disable uploading <LivingDoc.html> artifact automatically"
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
-    #- name: Checkout TODO on composite action 'uses'
-      #uses: actions/checkout@v2
-    #- name: Setup .NET Core
-      #uses: actions/setup-dotnet@v1
-      #with:
-        #dotnet-version: 3.1.x
     - name: BuildDotnetApp
       run: |
-        if [ ${{ inputs.no-build }} == 'true' ]; then
-          echo 'Build Skipped'
-        elif [ ${{ inputs.framework }} == 'null' ]; then
-          dotnet build -c ${{ inputs.configuration }} -v ${{ inputs.build-verbosity }}
-        else
-          dotnet build -c ${{ inputs.configuration }} -v ${{ inputs.build-verbosity }} -f ${{ inputs.framework }}
-        fi
+        _args=()
+        [ "${{ inputs.configuration }}" != 'null' ] && _args+=("-c" "${{ inputs.configuration }}")
+        [ "${{ inputs.build-verbosity }}" != 'null' ] && _args+=("-v" "${{ inputs.build-verbosity }}")
+        [ "${{ inputs.framework }}" != 'null' ] && _args+=("-f" "${{ inputs.framework }}")
+
+        [ ${{ inputs.no-build }} == 'true' ] && echo 'Build Skipped' || dotnet build "${_args[@]}"
       shell: bash
     - name: RunSpecFlowTests
       run: |
-        if   [ ${{ inputs.logger }} == 'null' ] || [ ${{ inputs.logger-file-name }} == 'null' ] && [ ${{ inputs.framework }} == 'null' ]; then
-          dotnet test --no-build -c ${{ inputs.configuration }} -v ${{ inputs.test-verbosity }}
-        elif [ ${{ inputs.logger }} == 'null' ] || [ ${{ inputs.logger-file-name }} == 'null' ]; then
-          dotnet test --no-build -c ${{ inputs.configuration }} -v ${{ inputs.test-verbosity }} -f ${{ inputs.framework }}
-        elif [ ${{ inputs.framework }} == 'null' ]; then
-          dotnet test --no-build -c ${{ inputs.configuration }} -v ${{ inputs.test-verbosity }} -l "${{ inputs.logger }};verbosity=${{ inputs.test-verbosity }};LogFileName=${{ inputs.logger-file-name }}"
-        else
-          dotnet test --no-build -c ${{ inputs.configuration }} -v ${{ inputs.test-verbosity }} -f ${{ inputs.framework }} -l "${{ inputs.logger }};verbosity=${{ inputs.test-verbosity }};LogFileName=${{ inputs.logger-file-name }}"
+        _args=()
+        _logger_args=()
+        [ "${{ inputs.configuration }}" != 'null' ] && _args+=("-c" "${{ inputs.configuration }}")
+        [ "${{ inputs.build-verbosity }}" != 'null' ] && _args+=("-v" "${{ inputs.build-verbosity }}")
+        [ "${{ inputs.framework }}" != 'null' ] && _args+=("-f" "${{ inputs.framework }}")
+        [ "${{ inputs.test-verbosity }}" != 'null' ] && _logger_args+=(";verbosity=${{ inputs.test-verbosity }}")
+        [ "${{ inputs.logger-file-name }}" != 'null' ] && _logger_args+=(";LogFileName=${{ inputs.logger-file-name }}")
+        [ "${{ inputs.logger }}" != 'null' ] && _args+=("-l" "${{ inputs.logger }}$(IFS=; echo "${_logger_args[@]}")")
+        
+        if ! dotnet test --no-build "${_args[@]}"; then
+            echo "_EXIT=1" >> $GITHUB_ENV
         fi
       shell: bash
-    - name: GenerateSpecFlowLivingDoc
+      continue-on-error: true
+    - name: GenerateLivingSpec
       run: |
+        [ "${{ inputs.test-assembly-path }}" != 'null' ] && _path="${{ inputs.test-assembly-path }}"
+        _dll="${_path:+$_path/}${{ inputs.test-assembly-dll }}"
+        _test="${_path:+$_path/}${{ inputs.test-execution-json }}"
+
         dotnet tool install --global SpecFlow.Plus.LivingDoc.CLI
-        if [ ${{ inputs.test-assembly-path }} != 'null' ]; then
-          livingdoc test-assembly ${{ inputs.test-assembly-path }}/${{ inputs.test-assembly-dll }} -t ${{ inputs.test-assembly-path }}/${{ inputs.test-execution-json }} -o ${{ inputs.output-html }}
-        else
-          livingdoc test-assembly ${{ inputs.test-assembly-dll }} -t ${{ inputs.test-execution-json }} -o ${{ inputs.output-html }}
-        fi
+        livingdoc test-assembly "$_dll" -t "$_test" -o "${{ inputs.output-html }}"
       shell: bash
-    #- name: 'Publish Specflow Test Results'
-      #uses: actions/upload-artifact@v2
-      #with:
-        #name: 'Specflow Test Results'
-        #path: ${{ output-html }}
+    - name: 'Publish Specflow Test Results'
+      if: ${{ inputs.upload-artifact == 'true' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: 'Specflow Test Results'
+        path: ${{ inputs.output-html }}
+    - name: ReturnCode
+      run: |
+        echo "${_EXIT:-0}"
+      shell: bash


### PR DESCRIPTION
## New Features
- Autopublish artefacts
- When test pipeline fails, due to failing tests, artefacts are still generated
- Workflow now uses local action for easier testing
- Added test for upload-artifact: false

## Changes
- Bash cleanup 
- .NET 6.0

## Notes
My thoughts are people integrating this will already need to checkout and configure .NET to build their project - so I removed this todo from the code, but still exists in the README should you consider it necessary. Personally, while not tested,  I think it would run the steps twice and eat up build time.