### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,5 +98,5 @@ runs:
         path: ${{ inputs.output-html }}
     - name: ReturnCode
       run: |
-        echo "${_EXIT:-0}"
+        exit "${_EXIT:-0}"
       shell: bash


### PR DESCRIPTION
I'm confident this used to work, but recently it hasn't been failing the GitHub action if the tests fail.

I've changed the line to now `exit` which allows the GitHub action to return a Red Cross when the tests fail.