### PR TITLE
docs: fix action name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ steps:
 - uses: actions/setup-dotnet@v4
   with:
     dotnet-version: '7.0.x'
-- uses: actions/cryptic-wizard/run-specflow-tests@v1.3.3
+- uses: cryptic-wizard/run-specflow-tests@v1.3.3
   with:
     test-assembly-path: MySpecflowProject/bin/Release/net7.0
     test-assembly-dll: MySpecflowProject.dll
@@ -43,7 +43,7 @@ jobs:
   - uses: actions/setup-dotnet@v4
     with:
       dotnet-version: '7.0.x'
-  - uses: actions/cryptic-wizard/run-specflow-tests@v1.3.3
+  - uses: cryptic-wizard/run-specflow-tests@v1.3.3
     with:
       test-assembly-path: MySpecflowProject/bin/Release/net7.0
       test-assembly-dll: MySpecflowProject.dll
@@ -60,7 +60,7 @@ jobs:
 
 #### Optional parameters:
 ```yaml
-- uses: actions/cryptic-wizard/run-specflow-tests@v1.3.3
+- uses: cryptic-wizard/run-specflow-tests@v1.3.3
   with:
     test-assembly-path: MySpecflowProject/bin/Debug/net7.0
     test-assembly-dll: MySpecflowProject.dll


### PR DESCRIPTION
fix Error: Unable to resolve action actions/cryptic-wizard, repository not found

Thanks for this great action. However, I met error when follow the README:

<img width="661" alt="image" src="https://github.com/user-attachments/assets/8f896839-d802-49a3-b52a-54a8ac028da9">


By removing the prefix `actions/`, it works great now!